### PR TITLE
Fix #9 simplify readiness handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ ift.parent({
 ```
 
 ```javascript
-ift.child({
+var manager = ift.child({
   trustedOrigins: ['http://parentapp.com']
-}).ready(function(manager) {
-  var channel = manager.channel('test');
-  channel.on('request', function(id, method, params) {
-    console.log(method, params[0]); // hello child!
-    channel.respond(id, 'hello parent!');
-  });
+});
+var channel = manager.channel('test');
+channel.on('request', function(id, method, params) {
+  console.log(method, params[0]); // hello child!
+  channel.respond(id, 'hello parent!');
 });
 ```
 

--- a/example/exec/child.html
+++ b/example/exec/child.html
@@ -11,9 +11,7 @@
         trustedOrigins: ['http://127.0.0.1:8000']
       }).wiretap(function(direction, message) {
         ift.util.debug(direction, message);
-      }).ready(function(manager) {
-        var exec = manager.service('example', Exec);
-      });
+      }).service('example', Exec);
     </script>
   </body>
 </html>

--- a/library/child-transport.js
+++ b/library/child-transport.js
@@ -1,4 +1,5 @@
 var Transport = require('./transport');
+var bind = require('./util/bind');
 
 // Implement the transport class from the child's perspective.
 var ChildTransport = module.exports = Transport.extend({
@@ -7,11 +8,12 @@ var ChildTransport = module.exports = Transport.extend({
     this.isReady = true;
     this.parent = window.parent;
     Transport.apply(this, arguments);
-  },
 
-  listen: function() {
-    this.send('ready');
-    Transport.prototype.listen.apply(this, arguments);
+    // use this setTimeout to ensure child implementation is able define event
+    // listeners before parent is informed of readiness
+    setTimeout(bind(function() {
+      this.send('ready');
+    }, this), 0);
   },
 
   send: function(message) {

--- a/library/child-transport.js
+++ b/library/child-transport.js
@@ -4,13 +4,12 @@ var Transport = require('./transport');
 var ChildTransport = module.exports = Transport.extend({
 
   constructor: function() {
+    this.isReady = true;
     this.parent = window.parent;
     Transport.apply(this, arguments);
   },
 
   listen: function() {
-    this.readyState = 1;
-    this.trigger('ready');
     this.send('ready');
     Transport.prototype.listen.apply(this, arguments);
   },

--- a/library/parent-transport.js
+++ b/library/parent-transport.js
@@ -15,7 +15,7 @@ var ParentTransport = module.exports = Transport.extend({
     var once;
     this.on('incoming', once = function(message) {
       if (message !== 'ready') return;
-      this.readyState = 1;
+      this.isReady = true;
       this.trigger('ready');
       this.off('incoming', once, this);
     }, this);

--- a/library/transport.js
+++ b/library/transport.js
@@ -6,7 +6,7 @@ var Events  = require('./util/events'),
 
 // Base class for wrapping `iframe#postMessage`.
 var Transport = module.exports = function(targetOrigins) {
-  this.readyState = 0;
+  this.isReady = false;
   this.targetOrigins = targetOrigins || [];
   this.onMessage = bind(this.onMessage, this);
   this.listen();
@@ -17,7 +17,7 @@ mixin(Transport.prototype, Events, {
   ready: function(callback, context) {
     var transport = this, ready;
     context || (context = this);
-    if (this.isReady()) {
+    if (this.isReady) {
       callback.call(context, this);
     } else {
       this.on('ready', ready = function() {
@@ -39,10 +39,6 @@ mixin(Transport.prototype, Events, {
 
   // Implemented by subclasses.
   send: function() {},
-
-  isReady: function() {
-    return this.readyState === 1;
-  },
 
   wiretap: function(callback) {
     this.on('incoming', function(message) {

--- a/test/functional/index.js
+++ b/test/functional/index.js
@@ -11,18 +11,17 @@ afterEach(function() {
 
 it("facilitates multiplexed communication across origins", function(done) {
   var childStub = function(exec, ift) {
-    ift.child({
+    var manager = ift.child({
       trustedOrigins: PARENT_ORIGINS
-    }).ready(function(manager) {
-      var channel1 = manager.channel('channel1');
-      channel1.on('request', function(id, method, params) {
-        channel1.respond(id, 'channel1 response');
-      });
+    });
+    var channel1 = manager.channel('channel1');
+    channel1.on('request', function(id, method, params) {
+      channel1.respond(id, 'channel1 response');
+    });
 
-      var channel2 = manager.channel('channel2');
-      channel2.on('request', function(id, method, params) {
-        channel2.respond(id, 'channel2 response');
-      });
+    var channel2 = manager.channel('channel2');
+    channel2.on('request', function(id, method, params) {
+      channel2.respond(id, 'channel2 response');
     });
   };
 
@@ -50,21 +49,20 @@ it("facilitates multiplexed communication across origins", function(done) {
 
 it("keeps track of callbacks", function(done) {
   var childStub = function(exec, ift) {
-    ift.child({
+    var manager = ift.child({
       trustedOrigins: PARENT_ORIGINS
-    }).ready(function(manager) {
-      var channel1 = manager.channel('channel1');
-      channel1.on('request', function(id, method, params) {
-        setTimeout(function() {
-          channel1.respond(id, method + params);
-        });
+    });
+    var channel1 = manager.channel('channel1');
+    channel1.on('request', function(id, method, params) {
+      setTimeout(function() {
+        channel1.respond(id, method + params);
       });
+    });
 
-      var channel2 = manager.channel('channel2');
-      channel2.on('request', function(id, method, params) {
-        setTimeout(function() {
-          channel2.respond(id, method + params);
-        });
+    var channel2 = manager.channel('channel2');
+    channel2.on('request', function(id, method, params) {
+      setTimeout(function() {
+        channel2.respond(id, method + params);
       });
     });
   };
@@ -107,23 +105,22 @@ it("can handle lots of traffic", function(done) {
   this.timeout(5000);
 
   var childStub = function(exec, ift) {
-    ift.child({
+    var manager = ift.child({
       trustedOrigins: PARENT_ORIGINS
-    }).ready(function(manager) {
-      var channel1 = manager.channel('channel1');
-      channel1.on('request', function(id, method, params) {
-        setTimeout(function() {
-          channel1.respond(id, params - 2);
-        });
+    });
+    var channel1 = manager.channel('channel1');
+    channel1.on('request', function(id, method, params) {
+      setTimeout(function() {
+        channel1.respond(id, params - 2);
       });
+    });
 
-      var channel2 = manager.channel('channel2');
-      channel2.on('request', function(id, method, params) {
-        setTimeout(function() {
-          channel2.respond(id, params + 4);
-        });
+    var channel2 = manager.channel('channel2');
+    channel2.on('request', function(id, method, params) {
+      setTimeout(function() {
+        channel2.respond(id, params + 4);
       });
-    })
+    });
   };
 
   manager = ift.parent({

--- a/test/unit/transport.js
+++ b/test/unit/transport.js
@@ -135,11 +135,14 @@ describe('ParentTransport', function() {
 });
 
 describe('ChildTransport', function() {
-  it("sends 'ready' message on instantiation", function() {
+  it("sends 'ready' message on instantiation", function(done) {
     var postMessage = sinon.stub(window.parent, 'postMessage');
     var transport = new ChildTransport(['http://origin']);
-    sinon.assert.calledOnce(postMessage);
-    sinon.assert.calledWith(postMessage, 'ready', '*');
-    postMessage.restore();
+    setTimeout(function() {
+      sinon.assert.calledOnce(postMessage);
+      sinon.assert.calledWith(postMessage, 'ready', '*');
+      postMessage.restore();
+      done();
+    }, 0);
   });
 });


### PR DESCRIPTION
Not sure if this is really superior to the current implementation -- I kind of think they're both reasonable approaches.

At the end of the day, code in the child must setup its own event listeners for coordinating readiness with corresponding code in the parent.

With this PR, the internals are a little simpler (could probably change `readyState: 0|1` to `isReady: t|f` anyway) and the child doesn't need a ready callback. It assumes `postMessage` is async, so child event handlers are actually setup before the parent is told everything's ready -- though we may want to add a `setTimeout` to ensure that.